### PR TITLE
Fixed log plugin id problem.

### DIFF
--- a/thundra/plugins/log/log_plugin.py
+++ b/thundra/plugins/log/log_plugin.py
@@ -1,5 +1,3 @@
-import uuid
-
 from thundra import utils, constants
 from thundra.plugins.log.thundra_log_handler import logs
 
@@ -17,7 +15,6 @@ class LogPlugin:
         context = data['context']
         logs.clear()
         self.log_data = {
-            'id': str(uuid.uuid4()),
             'transactionId': data['transactionId'],
             'applicationName': getattr(context, 'function_name', None),
             'applicationId': utils.get_application_id(context),

--- a/thundra/plugins/log/thundra_log_handler.py
+++ b/thundra/plugins/log/thundra_log_handler.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 
 logs = []
 
@@ -11,6 +12,7 @@ class ThundraLogHandler(logging.Handler):
     def emit(self, record):
         formatted_message = self.format(record)
         log = {
+            'id': str(uuid.uuid4()),
             'log': formatted_message,
             'logMessage': record.msg,
             'loggerName': record.name,


### PR DESCRIPTION
 - When multiple logs are sent, id was not generated separately for each log data, so all logs cannot be seen in UI.